### PR TITLE
Deep Negative Taggers update

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -322,6 +322,51 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
     ## setup all required btagInfos : we give a dedicated treatment for different
     ## types of tagInfos here. A common treatment is possible but might require a more
     ## general approach anyway in coordination with the btagging POG.
+
+    runNegativeVertexing = False
+    runNegativeCvsLVertexing = False
+    for btagInfo in requiredTagInfos:
+        if btagInfo == 'pfInclusiveSecondaryVertexFinderNegativeTagInfos' or btagInfo == 'pfNegativeDeepFlavourTagInfos':
+            runNegativeVertexing = True
+        if btagInfo == 'pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos':
+            runNegativeCvsLVertexing = True
+            
+    if runNegativeVertexing or runNegativeCvsLVertexing:
+        import RecoVertex.AdaptiveVertexFinder.inclusiveNegativeVertexing_cff as NegVertex
+
+    if runNegativeVertexing:                
+        addToProcessAndTask(btagPrefix+'inclusiveCandidateNegativeVertexFinder'+labelName+postfix,
+                            NegVertex.inclusiveCandidateNegativeVertexFinder.clone(primaryVertices = pvSource,tracks=pfCandidates),
+                            process, task)
+        addToProcessAndTask(btagPrefix+'candidateNegativeVertexMerger'+labelName+postfix,
+                            NegVertex.candidateNegativeVertexMerger.clone(secondaryVertices = cms.InputTag(btagPrefix+'inclusiveCandidateNegativeVertexFinder'+labelName+postfix)),
+                            process, task)
+        addToProcessAndTask(btagPrefix+'candidateNegativeVertexArbitrator'+labelName+postfix,
+                            NegVertex.candidateNegativeVertexArbitrator.clone( secondaryVertices = cms.InputTag(btagPrefix+'candidateNegativeVertexMerger'+labelName+postfix)
+                                                                               ,primaryVertices = pvSource
+                                                                               ,tracks=pfCandidates),
+                            process, task)
+        addToProcessAndTask(btagPrefix+'inclusiveCandidateNegativeSecondaryVertices'+labelName+postfix,
+                            NegVertex.inclusiveCandidateNegativeSecondaryVertices.clone(secondaryVertices = cms.InputTag(btagPrefix+'candidateNegativeVertexArbitrator'+labelName+postfix)),
+                            process, task)
+
+    if runNegativeCvsLVertexing:
+        addToProcessAndTask(btagPrefix+'inclusiveCandidateNegativeVertexFinderCvsL'+labelName+postfix,
+                            NegVertex.inclusiveCandidateNegativeVertexFinderCvsL.clone(primaryVertices = pvSource,tracks=pfCandidates),
+                            process, task)
+        addToProcessAndTask(btagPrefix+'candidateNegativeVertexMergerCvsL'+labelName+postfix,
+                            NegVertex.candidateNegativeVertexMergerCvsL.clone(secondaryVertices = cms.InputTag(btagPrefix+'inclusiveCandidateNegativeVertexFinderCvsL'+labelName+postfix)),
+                            process, task)
+        addToProcessAndTask(btagPrefix+'candidateNegativeVertexArbitratorCvsL'+labelName+postfix,
+                            NegVertex.candidateNegativeVertexArbitratorCvsL.clone( secondaryVertices = cms.InputTag(btagPrefix+'candidateNegativeVertexMergerCvsL'+labelName+postfix)
+                                                                               ,primaryVertices = pvSource
+                                                                               ,tracks=pfCandidates),
+                            process, task)
+        addToProcessAndTask(btagPrefix+'inclusiveCandidateNegativeSecondaryVerticesCvsL'+labelName+postfix,
+                            NegVertex.inclusiveCandidateNegativeSecondaryVerticesCvsL.clone(secondaryVertices = cms.InputTag(btagPrefix+'candidateNegativeVertexArbitratorCvsL'+labelName+postfix)),
+                            process, task)
+
+
     acceptedTagInfos = list()
     for btagInfo in requiredTagInfos:
         if hasattr(btag,btagInfo):
@@ -464,7 +509,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                 addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
                                     btag.pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos.clone(
                                         trackIPTagInfos = cms.InputTag(btagPrefix+'pfImpactParameterTagInfos'+labelName+postfix),
-                                        extSVCollection=svSourceCvsL),
+                                        extSVCollection = btagPrefix+'inclusiveCandidateNegativeSecondaryVerticesCvsL'+labelName+postfix),
                                     process, task)
                 if svClustering or fatJets != cms.InputTag(''):
                     setupSVClustering(getattr(process, btagPrefix+btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
@@ -486,7 +531,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                 addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
                                     btag.pfInclusiveSecondaryVertexFinderNegativeTagInfos.clone(
                                         trackIPTagInfos = cms.InputTag(btagPrefix+'pfImpactParameterTagInfos'+labelName+postfix),
-                                        extSVCollection=svSource),
+                                        extSVCollection=cms.InputTag(btagPrefix+'inclusiveCandidateNegativeSecondaryVertices'+labelName+postfix)),
                                     process, task)
                 if svClustering or fatJets != cms.InputTag(''):
                     setupSVClustering(getattr(process, btagPrefix+btagInfo+labelName+postfix), svClustering, algo, rParam, fatJets, groomedFatJets)
@@ -548,12 +593,14 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                     process, task)
 
             if 'DeepFlavourTagInfos' in btagInfo:
-
+                svUsed = svSource
                 if btagInfo == 'pfNegativeDeepFlavourTagInfos':
-                    deep_csv_tag_infos = 'pfDeepCSVNegativeTagInfos' 
+                    deep_csv_tag_infos = 'pfDeepCSVNegativeTagInfos'
+                    svUsed = cms.InputTag(btagPrefix+'inclusiveCandidateNegativeSecondaryVertices'+labelName+postfix)
+                    flip = True 
                 else:
                     deep_csv_tag_infos = 'pfDeepCSVTagInfos' 
-
+                    flip = False
                 # use right input tags when running with RECO PF candidates, which actually
                 # depens of wether jets were slimmed or not (check for s/S-limmed in name)
                 if not ('limmed' in jetSource.value()):

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -613,10 +613,11 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                     btag.pfDeepFlavourTagInfos.clone(
                                       jets = jetSource,
                                       vertices=pvSource,
-                                      secondary_vertices=svSource,
+                                      secondary_vertices=svUsed,
                                       shallow_tag_infos = cms.InputTag(btagPrefix+deep_csv_tag_infos+labelName+postfix),
                                       puppi_value_map = puppi_value_map,
                                       vertex_associator = vertex_associator,
+                                      flip = flip
                                       ),
                                     process, task)
 

--- a/RecoBTag/Combined/python/deepFlavour_cff.py
+++ b/RecoBTag/Combined/python/deepFlavour_cff.py
@@ -15,8 +15,8 @@ pfDeepCSVNegativeTagInfos = pfDeepCSVTagInfos.clone(
 	)
 pfDeepCSVNegativeTagInfos.computer.vertexFlip = True
 pfDeepCSVNegativeTagInfos.computer.trackFlip = True
-pfDeepCSVNegativeTagInfos.computer.trackSelection.sip3dSigMax = 0
-pfDeepCSVNegativeTagInfos.computer.trackPseudoSelection.sip3dSigMax = 0
+pfDeepCSVNegativeTagInfos.computer.trackSelection.sip3dSigMax = 10.0
+pfDeepCSVNegativeTagInfos.computer.trackPseudoSelection.sip3dSigMax = 10.0
 pfDeepCSVNegativeTagInfos.computer.trackPseudoSelection.sip2dSigMin = -99999.9
 pfDeepCSVNegativeTagInfos.computer.trackPseudoSelection.sip2dSigMax = -2.0
 

--- a/RecoBTag/DeepFlavour/plugins/ChargedCandidateConverter.h
+++ b/RecoBTag/DeepFlavour/plugins/ChargedCandidateConverter.h
@@ -30,7 +30,19 @@ namespace btagbtvdeep {
                                             const reco::Jet & jet,
                                             const TrackInfoBuilder & track_info,
                                             const float & drminpfcandsv,
-                                            ChargedCandidateFeatures & c_pf_features) {
+                                            ChargedCandidateFeatures & c_pf_features,
+					    const bool flip) {
+
+	float TrackSip2dVal = track_info.getTrackSip2dVal();
+	float TrackSip2dSig = track_info.getTrackSip2dSig();
+	float TrackSip3dVal = track_info.getTrackSip3dVal();
+	float TrackSip3dSig = track_info.getTrackSip3dSig();
+	if(flip == true){
+	  TrackSip2dVal = -1.0*TrackSip2dVal;
+	  TrackSip2dSig = -1.0*TrackSip2dSig;
+	  TrackSip3dSig = -1.0*TrackSip3dSig;
+	  TrackSip3dVal = -1.0*TrackSip3dVal;
+	}
 
         c_pf_features.ptrel = catch_infs_and_bound(c_pf->pt()/jet.pt(),
                                                           0,-1,0,-1);
@@ -40,10 +52,10 @@ namespace btagbtvdeep {
         c_pf_features.btagPf_trackPPar       =catch_infs_and_bound(track_info.getTrackPPar(),    0,-1e5,1e5 );
         c_pf_features.btagPf_trackDeltaR     =catch_infs_and_bound(track_info.getTrackDeltaR(),  0,-5,5 );
         c_pf_features.btagPf_trackPParRatio  =catch_infs_and_bound(track_info.getTrackPParRatio(),0,-10,100);
-        c_pf_features.btagPf_trackSip3dVal   =catch_infs_and_bound(track_info.getTrackSip3dVal(), 0, -1,1e5 );
-        c_pf_features.btagPf_trackSip3dSig   =catch_infs_and_bound(track_info.getTrackSip3dSig(), 0, -1,4e4 );
-        c_pf_features.btagPf_trackSip2dVal   =catch_infs_and_bound(track_info.getTrackSip2dVal(), 0, -1,70 );
-        c_pf_features.btagPf_trackSip2dSig   =catch_infs_and_bound(track_info.getTrackSip2dSig(), 0, -1,4e4 );
+        c_pf_features.btagPf_trackSip3dVal   =catch_infs_and_bound(TrackSip3dVal, 0, -1,1e5 );
+        c_pf_features.btagPf_trackSip3dSig   =catch_infs_and_bound(TrackSip3dSig, 0, -1,4e4 );
+        c_pf_features.btagPf_trackSip2dVal   =catch_infs_and_bound(TrackSip2dVal, 0, -1,70 );
+        c_pf_features.btagPf_trackSip2dSig   =catch_infs_and_bound(TrackSip2dSig, 0, -1,4e4 );
         c_pf_features.btagPf_trackJetDistVal =catch_infs_and_bound(track_info.getTrackJetDistVal(),0,-20,1 );
 
 
@@ -56,9 +68,10 @@ namespace btagbtvdeep {
                                             const pat::Jet & jet,
                                             const TrackInfoBuilder & track_info,
                                             const float drminpfcandsv,
-                                            ChargedCandidateFeatures & c_pf_features) {
+                                            ChargedCandidateFeatures & c_pf_features,
+					    const bool flip) {
 
-        CommonCandidateToFeatures(c_pf, jet, track_info, drminpfcandsv, c_pf_features);
+        CommonCandidateToFeatures(c_pf, jet, track_info, drminpfcandsv, c_pf_features, flip);
     
         c_pf_features.vtx_ass = c_pf->pvAssociationQuality();
 
@@ -85,9 +98,10 @@ namespace btagbtvdeep {
                                           const float drminpfcandsv, const float puppiw,
                                           const int pv_ass_quality,
                                           const reco::VertexRef & pv, 
-                                          ChargedCandidateFeatures & c_pf_features) {
+                                          ChargedCandidateFeatures & c_pf_features,
+					  const bool flip) {
 
-        CommonCandidateToFeatures(c_pf, jet, track_info, drminpfcandsv, c_pf_features);
+        CommonCandidateToFeatures(c_pf, jet, track_info, drminpfcandsv, c_pf_features, flip);
     
         c_pf_features.vtx_ass = (float) pat::PackedCandidate::PVAssociationQuality(qualityMap[pv_ass_quality]);
         if (c_pf->trackRef().isNonnull() && 

--- a/RecoBTag/DeepFlavour/plugins/DeepFlavourTagInfoProducer.cc
+++ b/RecoBTag/DeepFlavour/plugins/DeepFlavourTagInfoProducer.cc
@@ -18,6 +18,7 @@
 
 #include "DataFormats/BTauReco/interface/DeepFlavourTagInfo.h"
 #include "DataFormats/BTauReco/interface/DeepFlavourFeatures.h"
+#include "DataFormats/GeometryVector/interface/VectorUtil.h"
 
 #include "JetConverter.h"
 #include "BTagConverter.h"
@@ -27,7 +28,7 @@
 
 #include "TrackInfoBuilder.h"
 #include "sorting_modules.h"
-
+#include "deep_helpers.h"
 
 
 class DeepFlavourTagInfoProducer : public edm::stream::EDProducer<> {
@@ -51,6 +52,7 @@ class DeepFlavourTagInfoProducer : public edm::stream::EDProducer<> {
 
     const double jet_radius_;
     const double min_candidate_pt_;
+    const bool flip_;
 
     edm::EDGetTokenT<edm::View<reco::Jet>>  jet_token_;
     edm::EDGetTokenT<VertexCollection> vtx_token_;
@@ -71,6 +73,7 @@ class DeepFlavourTagInfoProducer : public edm::stream::EDProducer<> {
 DeepFlavourTagInfoProducer::DeepFlavourTagInfoProducer(const edm::ParameterSet& iConfig) :
   jet_radius_(iConfig.getParameter<double>("jet_radius")),
   min_candidate_pt_(iConfig.getParameter<double>("min_candidate_pt")),
+  flip_(iConfig.getParameter<bool>("flip")),
   jet_token_(consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("jets"))),
   vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
   sv_token_(consumes<SVCollection>(iConfig.getParameter<edm::InputTag>("secondary_vertices"))),
@@ -109,6 +112,7 @@ void DeepFlavourTagInfoProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<edm::InputTag>("shallow_tag_infos", edm::InputTag("pfDeepCSVTagInfos"));
   desc.add<double>("jet_radius", 0.4);
   desc.add<double>("min_candidate_pt", 0.95);
+  desc.add<bool>("flip", false);
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
   desc.add<edm::InputTag>("puppi_value_map", edm::InputTag("puppi"));
   desc.add<edm::InputTag>("secondary_vertices", edm::InputTag("inclusiveCandidateSecondaryVertices"));
@@ -192,6 +196,11 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
     // fill number of pv
     features.npv = vtxs->size();
 
+    math::XYZVector jet_dir = jet.momentum().Unit();
+    GlobalVector jet_ref_track_dir(jet.px(),
+                                   jet.py(),
+                                   jet.pz());
+
     // fill features from ShallowTagInfo
     const auto & tag_info_vars = tag_info.taggingVariables();
     btagbtvdeep::BTagConverter::BTagToFeatures(tag_info_vars, features.tag_info_features);
@@ -204,20 +213,16 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
               { return btagbtvdeep::sv_vertex_comparator(sva, svb, pv); });
     // fill features from secondary vertices
     for (const auto & sv : svs_sorted) {
-      if (reco::deltaR(sv, jet) > jet_radius_) continue;
+      if (Geom::deltaR(sv.position() - pv.position(), flip_ ? -jet_dir : jet_dir) > jet_radius_) continue;
       else {
         features.sv_features.emplace_back();
         // in C++17 could just get from emplace_back output
         auto & sv_features = features.sv_features.back();
-        btagbtvdeep::SVConverter::SVToFeatures(sv, pv, jet, sv_features);
+        btagbtvdeep::SVConverter::SVToFeatures(sv, pv, jet, sv_features, flip_);
       }
     }
 
     // stuff required for dealing with pf candidates
-    math::XYZVector jet_dir = jet.momentum().Unit();
-    GlobalVector jet_ref_track_dir(jet.px(),
-                                   jet.py(),
-                                   jet.pz());
 
     std::vector<btagbtvdeep::SortingClass<size_t> > c_sorted, n_sorted;
 
@@ -300,12 +305,13 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
       auto entry = c_sortedindices.at(i);
       // get cached track info
       auto & trackinfo = trackinfos.at(i);
+      if(flip_ && (trackinfo.getTrackSip3dSig() > 10.0)){continue;}
       // get_ref to vector element
       auto & c_pf_features = features.c_pf_features.at(entry);
       // fill feature structure
       if (packed_cand) {
         btagbtvdeep::ChargedCandidateConverter::PackedCandidateToFeatures(packed_cand, jet, trackinfo,
-                                                                          drminpfcandsv, c_pf_features);
+                                                                          drminpfcandsv, c_pf_features, flip_);
       } else if (reco_cand) {
         // get vertex association quality
         int pv_ass_quality = 0; // fallback value
@@ -333,7 +339,7 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
         btagbtvdeep::ChargedCandidateConverter::RecoCandidateToFeatures(
             reco_cand, jet, trackinfo,
             drminpfcandsv, puppiw, pv_ass_quality,
-            PV, c_pf_features);
+            PV, c_pf_features, flip_);
       }
     } else {
       // is neutral candidate

--- a/RecoBTag/DeepFlavour/plugins/SVConverter.h
+++ b/RecoBTag/DeepFlavour/plugins/SVConverter.h
@@ -15,12 +15,13 @@ namespace btagbtvdeep {
 
       static void SVToFeatures( const reco::VertexCompositePtrCandidate & sv,
                                 const reco::Vertex & pv, const reco::Jet & jet,
-                                SecondaryVertexFeatures & sv_features) {
-    
+                                SecondaryVertexFeatures & sv_features,
+				const bool flip) {
+
+	math::XYZVector jet_dir = jet.momentum().Unit();
         sv_features.pt = sv.pt();
-        sv_features.deltaR = catch_infs_and_bound(
-                               std::fabs(reco::deltaR(sv,jet))-0.5,
-                               0,-2,0);
+        sv_features.deltaR = catch_infs_and_bound(std::fabs(Geom::deltaR(sv.position() - pv.position(), flip ? -jet_dir : jet_dir))-0.5,
+						  0,-2,0);
         sv_features.mass = sv.mass();
         sv_features.ntracks = sv.numberOfDaughters();
         sv_features.chi2 = sv.vertexChi2();
@@ -34,7 +35,11 @@ namespace btagbtvdeep {
         sv_features.d3d = d3d_meas.value();
         sv_features.d3dsig = catch_infs_and_bound(d3d_meas.value()/d3d_meas.error(),
                                                   0,-1,800);
-        sv_features.costhetasvpv = vertexDdotP(sv,pv);
+	float costhetasvpv = vertexDdotP(sv,pv);
+	if(flip){
+	  costhetasvpv = -1.0*costhetasvpv;
+	}
+        sv_features.costhetasvpv = costhetasvpv;
         sv_features.enratio = sv.energy()/jet.energy();
     
       } 

--- a/RecoBTag/DeepFlavour/python/pfNegativeDeepFlavourTagInfos_cfi.py
+++ b/RecoBTag/DeepFlavour/python/pfNegativeDeepFlavourTagInfos_cfi.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.DeepFlavour.pfDeepFlavourTagInfos_cfi import pfDeepFlavourTagInfos
 
 pfNegativeDeepFlavourTagInfos = pfDeepFlavourTagInfos.clone(
-        shallow_tag_infos = cms.InputTag('pfDeepCSVNegativeTagInfos')
+        shallow_tag_infos = cms.InputTag('pfDeepCSVNegativeTagInfos'),
+        flip = cms.bool(True)
         )

--- a/RecoBTag/DeepFlavour/python/pfNegativeDeepFlavourTagInfos_cfi.py
+++ b/RecoBTag/DeepFlavour/python/pfNegativeDeepFlavourTagInfos_cfi.py
@@ -4,5 +4,6 @@ from RecoBTag.DeepFlavour.pfDeepFlavourTagInfos_cfi import pfDeepFlavourTagInfos
 
 pfNegativeDeepFlavourTagInfos = pfDeepFlavourTagInfos.clone(
         shallow_tag_infos = cms.InputTag('pfDeepCSVNegativeTagInfos'),
+        secondary_vertices = cms.InputTag('inclusiveCandidateNegativeSecondaryVertices'),
         flip = cms.bool(True)
         )

--- a/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h
@@ -143,7 +143,7 @@ void CombinedSVComputer::fillCommonVariables(reco::TaggingVariableList & vars, r
 		vars.insert(btau::flightDistance2dSig,flipValue(svInfo.flightDistance(vtx, 2).significance(),true),true);
 		vars.insert(btau::flightDistance3dVal,flipValue(svInfo.flightDistance(vtx, 3).value(),true),true);
 		vars.insert(btau::flightDistance3dSig,flipValue(svInfo.flightDistance(vtx, 3).significance(),true),true);
-		vars.insert(btau::vertexJetDeltaR,Geom::deltaR(svInfo.flightDirection(vtx), jetDir),true);
+		vars.insert(btau::vertexJetDeltaR,Geom::deltaR(svInfo.flightDirection(vtx), vertexFlip ? -jetDir : jetDir),true);
 		vars.insert(btau::jetNSecondaryVertices, svInfo.nVertices(), true);
 	}
 
@@ -245,10 +245,22 @@ void CombinedSVComputer::fillCommonVariables(reco::TaggingVariableList & vars, r
 	vars.insert(btau::trackSumJetDeltaR,VectorUtil::DeltaR(allKinematics.vectorSum(), jetDir), true);
 	vars.insert(btau::trackSumJetEtRatio,allKinematics.vectorSum().Et() / ipInfo.jet()->et(), true);
 	
-	vars.insert(btau::trackSip3dSigAboveCharm, flipValue(threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv).ip3d.significance(),false),true);
-	vars.insert(btau::trackSip3dValAboveCharm, flipValue(threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv).ip3d.value(),false),true);
-	vars.insert(btau::trackSip2dSigAboveCharm, flipValue(threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv).ip2d.significance(),false),true);
-	vars.insert(btau::trackSip2dValAboveCharm, flipValue(threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv).ip2d.value(),false),true);
+	float trackSip3dSigAboveCharm = threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv).ip3d.significance();
+	float trackSip3dValAboveCharm = threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv).ip3d.value();
+	float trackSip2dSigAboveCharm = threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv).ip2d.significance();
+	float trackSip2dValAboveCharm = threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv).ip2d.value();
+
+	if( (trackSip2dValAboveCharm == -1) && (trackSip3dValAboveCharm == -1) && trackFlip ){
+	  trackSip3dSigAboveCharm = -trackSip3dSigAboveCharm; 
+	  trackSip3dValAboveCharm = -trackSip3dValAboveCharm; 
+	  trackSip2dSigAboveCharm = -trackSip2dSigAboveCharm;
+	  trackSip2dValAboveCharm = -trackSip2dValAboveCharm;
+	}
+
+	vars.insert(btau::trackSip3dSigAboveCharm, flipValue(trackSip3dSigAboveCharm,false),true);
+	vars.insert(btau::trackSip3dValAboveCharm, flipValue(trackSip3dValAboveCharm,false),true);
+	vars.insert(btau::trackSip2dSigAboveCharm, flipValue(trackSip2dSigAboveCharm,false),true);
+	vars.insert(btau::trackSip2dValAboveCharm, flipValue(trackSip2dValAboveCharm,false),true);
 
         if (vtxType != btag::Vertices::NoVertex) {
                 math::XYZTLorentzVector allSum = useTrackWeights

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -860,9 +860,10 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
 		  else {
 		      for(size_t iExtSv = 0; iExtSv < extSecVertex->size(); iExtSv++){
 			 const VTX & extVertex = (*extSecVertex)[iExtSv];
-			 if( Geom::deltaR2( ( position(extVertex) - pv.position() ), jetDir ) > extSVDeltaRToJet*extSVDeltaRToJet || extVertex.p4().M() < 0.3 )
+			 if( Geom::deltaR2( ( position(extVertex) - pv.position() ), (extSVDeltaRToJet > 0) ? jetDir : -jetDir ) > extSVDeltaRToJet*extSVDeltaRToJet || extVertex.p4().M() < 0.3 )
 			   continue;
 			 extAssoCollection.push_back( extVertex );
+			
 		      }
 		  }
 		  // build combined SV information and filter

--- a/RecoBTag/SecondaryVertex/python/pfInclusiveSecondaryVertexFinderNegativeTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/pfInclusiveSecondaryVertexFinderNegativeTagInfos_cfi.py
@@ -4,6 +4,7 @@ from RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderTagInfos_cfi impor
 
 pfInclusiveSecondaryVertexFinderNegativeTagInfos = pfInclusiveSecondaryVertexFinderTagInfos.clone()
 pfInclusiveSecondaryVertexFinderNegativeTagInfos.extSVDeltaRToJet = cms.double(-0.3)
+pfInclusiveSecondaryVertexFinderNegativeTagInfos.extSVCollection  = cms.InputTag('inclusiveCandidateNegativeSecondaryVertices')
 pfInclusiveSecondaryVertexFinderNegativeTagInfos.vertexCuts.distVal2dMin = -2.5
 pfInclusiveSecondaryVertexFinderNegativeTagInfos.vertexCuts.distVal2dMax = -0.01
 pfInclusiveSecondaryVertexFinderNegativeTagInfos.vertexCuts.distSig2dMin = -99999.9

--- a/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitratration.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitratration.h
@@ -72,7 +72,8 @@ class TrackVertexArbitration{
 	double 					fitterRatio;//    = 0.25;
 	int 					trackMinLayers;
 	double					trackMinPt;
-	int					trackMinPixels;   
+	int					trackMinPixels;
+	double                                  sign;
 };
 
 #include "DataFormats/GeometryVector/interface/VectorUtil.h"
@@ -93,7 +94,9 @@ TrackVertexArbitration<VTX>::TrackVertexArbitration(const edm::ParameterSet &par
 	trackMinPt                (params.getParameter<double>("trackMinPt")),
 	trackMinPixels            (params.getParameter<int32_t>("trackMinPixels"))
 {
-	dRCut*=dRCut;
+        sign = 1.0;
+        if(dRCut < 0){sign = -1.0;}
+        dRCut*=dRCut;
 }
 template <class VTX>
 bool TrackVertexArbitration<VTX>::trackFilterArbitrator(const reco::TransientTrack &track) const
@@ -155,12 +158,10 @@ std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
 	std::vector<VTX> recoVertices;
         VertexDistance3D vdist;
         GlobalPoint ppv(pv.position().x(),pv.position().y(),pv.position().z());
-
         std::map<unsigned int, Measurement1D> cachedIP;  
         for(typename std::vector<VTX>::const_iterator sv = secondaryVertices.begin();
 	    sv != secondaryVertices.end(); ++sv) {
-
-	    GlobalPoint ssv(sv->position().x(),sv->position().y(),sv->position().z());
+	  GlobalPoint ssv(sv->position().x(),sv->position().y(),sv->position().z());
             GlobalVector flightDir = ssv-ppv;
 //            std::cout << "Vertex : " << sv-secondaryVertices->begin() << " " << sv->position() << std::endl;
             Measurement1D dlen= vdist.distance(pv,VertexState(RecoVertex::convertPos(sv->position()),RecoVertex::convertError(sv->error())));
@@ -186,19 +187,20 @@ std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
 		GlobalError refPointErr       = tsos.cartesianError().position();
 		Measurement1D isv = dist.distance(VertexState(RecoVertex::convertPos(sv->position()),RecoVertex::convertError(sv->error())),VertexState(refPoint, refPointErr));	   
 
-		float dR = Geom::deltaR2(flightDir,tt.track()); //.eta(), flightDir.phi(), tt.track().eta(), tt.track().phi());
+		float dR = Geom::deltaR2(( (sign > 0) ? flightDir : -flightDir),tt.track()); //.eta(), flightDir.phi(), tt.track().eta(), tt.track().phi());
 
                 if( w > 0 || ( isv.significance() < sigCut && isv.value() < distCut && isv.value() < dlen.value()*dLenFraction ) )
                 {
 
                   if(( isv.value() < ipv.value()  ) && isv.value() < distCut && isv.value() < dlen.value()*dLenFraction 
-                  && dR < dRCut  ) 
+		     && dR < dRCut  ) 
                   {
 #ifdef VTXDEBUG
                      if(w > 0.5) std::cout << " = ";
                     else std::cout << " + ";
 #endif 
                      selTracks.push_back(tt);
+
                   } else
                   {
 #ifdef VTXDEBUG
@@ -212,7 +214,7 @@ std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
                        std::cout << " = ";
 #endif
                      }
-                     if(w > 0.5 && isv.value() <= ipv.value() && dR >= dRCut) {
+                     if(w > 0.5 && isv.value() <= ipv.value() && dR >= std::fabs(dRCut)) {
 #ifdef VTXDEBUG
                        std::cout << " - ";
 #endif

--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
@@ -211,11 +211,11 @@ void TemplatedInclusiveVertexFinder<InputContainer,VTX>::produce(edm::Event &eve
 #endif
                         }
 			GlobalPoint sv((*v).position().x(),(*v).position().y(),(*v).position().z());
-			float vscal = dir.unit().dot((sv-ppv).unit()) ;
-			//                        std::cout << "Vscal: " <<  vscal << std::endl;
-			if(dlen.significance() > vertexMinDLenSig  && vscal > vertexMinAngleCosine &&  v->normalisedChiSquared() < 10 && dlen2.significance() > vertexMinDLen2DSig)
+			float vscal = dir.unit().dot((sv-ppv).unit());
+			if(dlen.significance() > vertexMinDLenSig  && ( (vertexMinAngleCosine > 0) ? (vscal > vertexMinAngleCosine) : (vscal < vertexMinAngleCosine) ) &&  v->normalisedChiSquared() < 10 && dlen2.significance() > vertexMinDLen2DSig)
 			{	 
 				recoVertices->push_back(*v);
+
 #ifdef VTXDEBUG
 	                        std::cout << "ADDED" << std::endl;
 #endif

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveNegativeVertexing_cff.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveNegativeVertexing_cff.py
@@ -1,0 +1,62 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoVertex.AdaptiveVertexFinder.inclusiveCandidateVertexFinder_cfi import *
+from RecoVertex.AdaptiveVertexFinder.candidateVertexMerger_cfi import *
+from RecoVertex.AdaptiveVertexFinder.candidateVertexArbitrator_cfi import *
+
+
+inclusiveCandidateNegativeVertexFinder = inclusiveCandidateVertexFinder.clone(
+   vertexMinAngleCosine = cms.double(-0.95) 
+)
+inclusiveCandidateNegativeVertexFinder.clusterizer.clusterMinAngleCosine = cms.double(-0.5)
+
+candidateNegativeVertexMerger = candidateVertexMerger.clone()
+candidateNegativeVertexMerger.secondaryVertices = cms.InputTag("inclusiveCandidateNegativeVertexFinder")
+
+candidateNegativeVertexArbitrator = candidateVertexArbitrator.clone()
+candidateNegativeVertexArbitrator.secondaryVertices = cms.InputTag("candidateNegativeVertexMerger")
+candidateNegativeVertexArbitrator.dRCut = cms.double(-0.4)
+
+inclusiveCandidateNegativeSecondaryVertices = candidateVertexMerger.clone()
+inclusiveCandidateNegativeSecondaryVertices.secondaryVertices = cms.InputTag("candidateNegativeVertexArbitrator")
+inclusiveCandidateNegativeSecondaryVertices.maxFraction = 0.2
+inclusiveCandidateNegativeSecondaryVertices.minSignificance = 10.
+
+
+
+inclusiveCandidateNegativeVertexingTask = cms.Task(inclusiveCandidateNegativeVertexFinder,
+                                           candidateNegativeVertexMerger,
+                                           candidateNegativeVertexArbitrator,
+                                           inclusiveCandidateNegativeSecondaryVertices)
+
+inclusiveCandidateNegativeVertexing = cms.Sequence(inclusiveCandidateNegativeVertexingTask)
+
+
+inclusiveCandidateNegativeVertexFinderCvsL = inclusiveCandidateVertexFinder.clone(
+   vertexMinDLen2DSig = cms.double(1.25),
+   vertexMinDLenSig = cms.double(0.25),
+   vertexMinAngleCosine = cms.double(-0.95)
+)
+inclusiveCandidateNegativeVertexFinderCvsL.clusterizer.clusterMinAngleCosine = cms.double(-0.5)
+
+candidateNegativeVertexMergerCvsL = candidateVertexMerger.clone(
+   secondaryVertices = cms.InputTag("inclusiveCandidateNegativeVertexFinderCvsL")
+)
+
+candidateNegativeVertexArbitratorCvsL = candidateVertexArbitrator.clone(
+   secondaryVertices = cms.InputTag("candidateNegativeVertexMergerCvsL"),
+   dRCut = cms.double(-0.4)
+)
+
+inclusiveCandidateNegativeSecondaryVerticesCvsL = candidateVertexMerger.clone(
+   secondaryVertices = cms.InputTag("candidateNegativeVertexArbitratorCvsL"),
+   maxFraction = cms.double(0.2),
+   minSignificance = cms.double(10.)
+)
+
+
+inclusiveCandidateNegativeVertexingCvsLTask = cms.Task(inclusiveCandidateNegativeVertexFinderCvsL,
+                                               candidateNegativeVertexMergerCvsL,
+                                               candidateNegativeVertexArbitratorCvsL,
+                                               inclusiveCandidateNegativeSecondaryVerticesCvsL)
+inclusiveCandidateNegativeVertexingCvsL = cms.Sequence(inclusiveCandidateNegativeVertexingCvsLTask)

--- a/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
+++ b/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
@@ -52,13 +52,13 @@ std::pair<std::vector<reco::TransientTrack>,GlobalPoint> TracksClusteringFromDis
 
                  float w = distanceFromPV*distanceFromPV/(pvDistance*distance);
           	 bool selected = (m.significance() < clusterMaxSignificance && 
-                    dotprodSeed > clusterMinAngleCosine && //Angles between PV-PCAonSeed vectors and seed directions
-                    dotprodTrack > clusterMinAngleCosine && //Angles between PV-PCAonTrack vectors and track directions
-//                    dotprodTrackSeed2D > clusterMinAngleCosine && //Angle between track and seed
-        //      distance*clusterScale*tracks.size() < (distanceFromPV+pvDistance)*(distanceFromPV+pvDistance)/pvDistance && // cut scaling with track density
-                   distance*distanceRatio < distanceFromPV && // cut scaling with track density
-                    distance < clusterMaxDistance);  // absolute distance cut
-
+				  ((clusterMinAngleCosine > 0) ? (dotprodSeed > clusterMinAngleCosine) : (dotprodSeed < clusterMinAngleCosine)) && //Angles between PV-PCAonSeed vectors and seed directions
+				  ((clusterMinAngleCosine > 0) ? (dotprodTrack > clusterMinAngleCosine) : (dotprodTrack < clusterMinAngleCosine)) && //Angles between PV-PCAonTrack vectors and track directions
+																      //                    dotprodTrackSeed2D > clusterMinAngleCosine && //Angle between track and seed
+																     //      distance*clusterScale*tracks.size() < (distanceFromPV+pvDistance)*(distanceFromPV+pvDistance)/pvDistance && // cut scaling with track density
+																     distance*distanceRatio < distanceFromPV && // cut scaling with track density
+																     distance < clusterMaxDistance);  // absolute distance cut
+      
 #ifdef VTXDEBUG
             	    std::cout << tt->trackBaseRef().key() << " :  " << (selected?"+":" ")<< " " << m.significance() << " < " << clusterMaxSignificance <<  " &&  " << 
                     dotprodSeed  << " > " <<  clusterMinAngleCosine << "  && " << 


### PR DESCRIPTION
For a description of the changes see:
https://indico.cern.ch/event/713923/contributions/2938152/attachments/1620844/2578707/NegativeTagger.pdf

Beside the changes described there, the vertex reconstructions had cuts on the angle between the flight direction of the vertex and the track direction. These need to be inverted for the negative taggers. A negative vertexing task has therefore been added as well.